### PR TITLE
clean branch 30 with black

### DIFF
--- a/src-back/classes.py
+++ b/src-back/classes.py
@@ -8,7 +8,8 @@ connection = sqlite3.connect(db_name)
 cursor = connection.cursor()
 print("Connected to the database")
 
-#%% Class Definitions
+
+# %% Class Definitions
 class Category:
     def __init__(self, id, name):
         self.id = id
@@ -61,9 +62,10 @@ class Card:
 
     def PrintCard(self):
         negative = "Negative " if self.isNegative else ""
-        print(f"{self.id}: {negative}{self.name} - {self.rarity}");
-        print(f" {self.effect}");
-        print(f" Adds: {self.adding} - Multiplies by: {self.multiplyBy}");
+        print(f"{self.id}: {negative}{self.name} - {self.rarity}")
+        print(f" {self.effect}")
+        print(f" Adds: {self.adding} - Multiplies by: {self.multiplyBy}")
+
 
 class Account:
     def __init__(self, id, broccolis, username, cards):
@@ -78,22 +80,28 @@ class Account:
 
     def EquipCard(self, card):
         self.cards = [[c, 1] if c == card else [c, v] for c, v in self.cards]
-        cursor.execute(f"UPDATE TABLE AccountCard SET isEquipped = 1 WHERE idAccount = {self.id} AND idCard = {card.id})")
+        cursor.execute(
+            f"UPDATE TABLE AccountCard SET isEquipped = 1 WHERE idAccount = {self.id} AND idCard = {card.id})"
+        )
 
     def UnequipCard(self, card):
         self.cards = [[c, 1] if c == card else [c, v] for c, v in self.cards]
-        cursor.execute(f"UPDATE TABLE AccountCard SET isEquipped = 0 WHERE idAccount = {self.id} AND idCard = {card.id})")
+        cursor.execute(
+            f"UPDATE TABLE AccountCard SET isEquipped = 0 WHERE idAccount = {self.id} AND idCard = {card.id})"
+        )
 
     def UserExists(login):
         cursor.execute("SELECT * FROM Account WHERE username = ?", (login,))
         return cursor.fetchone() is not None
-    
+
     def CreateUser(self, login, password):
         if self.UserExists(login):
             return {"status": "error", "message": "Username already exists"}
-        hashed_password = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
-        
-        cursor.execute("INSERT INTO Account (username, password) VALUES (?, ?)", (login, hashed_password))
+        hashed_password = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+        cursor.execute(
+            "INSERT INTO Account (username, password) VALUES (?, ?)", (login, hashed_password)
+        )
         connection.commit()
         return {"status": "success", "message": "User created successfully"}
 
@@ -102,15 +110,17 @@ class Account:
         result = cursor.fetchone()
         if result is None:
             return {"status": "error", "message": "User does not exist"}
-        
+
         stored_password = result[0]
-        if bcrypt.checkpw(password.encode('utf-8'), stored_password.encode('utf-8')):
+        if bcrypt.checkpw(password.encode("utf-8"), stored_password.encode("utf-8")):
             return {"status": "success", "message": "Password is correct"}
         else:
             return {"status": "error", "message": "Incorrect password"}
-#%%
 
-#%% Creating categories
+
+# %%
+
+# %% Creating categories
 sql_command = """
     SELECT w.id, w.word, c.id AS categoryId
     FROM Word w
@@ -138,9 +148,9 @@ categories = [Category(*category) for category in query]
 
 for category in categories:
     category.PrintCategory()
-#%%
+# %%
 
-#%% Creating words
+# %% Creating words
 sql_command = """
     SELECT w.id, w.word, c.id AS categoryId
     FROM Word w
@@ -149,8 +159,8 @@ sql_command = """
 """
 cursor.execute(sql_command)
 query = cursor.fetchall()
-#The dictionnary is used to check if we have already registered a word
-words_dict = {} 
+# The dictionnary is used to check if we have already registered a word
+words_dict = {}
 words = []
 for word in query:
     word_key = (word[0], word[1])
@@ -165,17 +175,17 @@ for word in query:
 for word in words:
     if len(word.category) > 1:
         word.PrintWord()
-        
-#%%
 
-#%% Creating Cards
+# %%
+
+# %% Creating Cards
 cursor.execute("SELECT id, name, effect, rarity, isNegative, adding, multiplyBy FROM Card;")
 query = cursor.fetchall()
 cards = [Card(*card) for card in query]
 
 for card in cards:
     card.PrintCard()
-#%%
+# %%
 
-connection.commit();
-connection.close();
+connection.commit()
+connection.close()

--- a/src-back/sql_script.py
+++ b/src-back/sql_script.py
@@ -1134,7 +1134,7 @@ words = {
 }
 # %%
 
-#%% Word Insertion
+# %% Word Insertion
 for category_name, word_list in words.items():
     for word in word_list:
         cursor.execute("INSERT OR IGNORE INTO Word (word) VALUES (?);", (word,))
@@ -1168,23 +1168,36 @@ cursor.execute(
             ('Super soil', 'Will multiply your broccoli production by 2 !', 'rare', 1, 0, 2)
     """
 )
-#%% CardEffect Insertion
+# %% CardEffect Insertion
 cursor.execute("INSERT INTO CardEffect (idEffect, name, value) VALUES (1, 'Add To Production', 1)")
 cursor.execute("INSERT INTO CardEffect (idEffect, name, value) VALUES (1, 'Add To Production', 2)")
 cursor.execute("INSERT INTO CardEffect (idEffect, name, value) VALUES (2, 'Add To Click', 1)")
 cursor.execute("INSERT INTO CardEffect (idEffect, name, value) VALUES (2, 'Add To Click', 5)")
-cursor.execute("INSERT INTO CardEffect (idEffect, name, value) VALUES (3, 'Multiply Production By', 2)")
-cursor.execute("INSERT INTO CardEffect (idEffect, name, value) VALUES (3, 'Multiply Production By', 3)")
+cursor.execute(
+    "INSERT INTO CardEffect (idEffect, name, value) VALUES (3, 'Multiply Production By', 2)"
+)
+cursor.execute(
+    "INSERT INTO CardEffect (idEffect, name, value) VALUES (3, 'Multiply Production By', 3)"
+)
 cursor.execute("INSERT INTO CardEffect (idEffect, name, value) VALUES (4, 'Multiply Clicks By', 2)")
 cursor.execute("INSERT INTO CardEffect (idEffect, name, value) VALUES (4, 'Multiply Clicks By', 3)")
-cursor.execute("INSERT INTO CardEffect (idEffect, name, value) VALUES (5, 'Add To Crit Chance', 0.1)")
-cursor.execute("INSERT INTO CardEffect (idEffect, name, value) VALUES (5, 'Add To Crit Chance', 0.25)")
-cursor.execute("INSERT INTO CardEffect (idEffect, name, value) VALUES (6, 'Multiply Crit Chance By', 2)")
-cursor.execute("INSERT INTO CardEffect (idEffect, name, value) VALUES (6, 'Multiply Crit Chance By', 3)")
-#%%
+cursor.execute(
+    "INSERT INTO CardEffect (idEffect, name, value) VALUES (5, 'Add To Crit Chance', 0.1)"
+)
+cursor.execute(
+    "INSERT INTO CardEffect (idEffect, name, value) VALUES (5, 'Add To Crit Chance', 0.25)"
+)
+cursor.execute(
+    "INSERT INTO CardEffect (idEffect, name, value) VALUES (6, 'Multiply Crit Chance By', 2)"
+)
+cursor.execute(
+    "INSERT INTO CardEffect (idEffect, name, value) VALUES (6, 'Multiply Crit Chance By', 3)"
+)
+# %%
 
-#%% Card Insertion & Verification
-cursor.execute("""INSERT INTO Card (name, effect, rarity, isNegative, idCardEffect) VALUES
+# %% Card Insertion & Verification
+cursor.execute(
+    """INSERT INTO Card (name, effect, rarity, isNegative, idCardEffect) VALUES
                    ('Farmer', 'Will add 1 broccoli to your account every second !', 'Common', 0, 1),
                    ('Farmer', 'Will add 1 broccoli to your account every second !', 'Common', 1, 1),
                    ('Super soil', 'Will multiply your broccoli production by 2 !', 'Rare', 0, 7),
@@ -1196,17 +1209,20 @@ cursor.execute("""INSERT INTO Card (name, effect, rarity, isNegative, idCardEffe
                    ('Beet', 'Gives you 10% more chance to Critical Click !', 'Rare', 0, 9),
                    ('Beet', 'Gives you 10% more chance to Critical Click !', 'Rare', 1, 9),
                    ('Butternut', 'Doubles your Critical Click chances !', 'Legendary', 0, 11),
-                   ('Butternut', 'Doubles your Critical Click chances !', 'Legendary', 1, 11)""")
+                   ('Butternut', 'Doubles your Critical Click chances !', 'Legendary', 1, 11)"""
+)
 
-cursor.execute("SELECT c.id, c.name, effect, rarity, isNegative, ce.name, ce.value FROM Card c, CardEffect ce WHERE c.idCardEffect = ce.id;")
+cursor.execute(
+    "SELECT c.id, c.name, effect, rarity, isNegative, ce.name, ce.value FROM Card c, CardEffect ce WHERE c.idCardEffect = ce.id;"
+)
 cards = cursor.fetchall()
 print("Cards in the database:")
 for card in cards:
     negative = "Negative " if card[4] else ""
-    print(f"{card[0]}: {negative}{card[1]} - {card[3]}");
-    print(f" {card[2]}");
-    print(f" {card[5]}: {card[6]}");
-#%%
+    print(f"{card[0]}: {negative}{card[1]} - {card[3]}")
+    print(f" {card[2]}")
+    print(f" {card[5]}: {card[6]}")
+# %%
 
 # %% Word & Category insert's verification
 sql_command = """


### PR DESCRIPTION
i currently only cleaned using 'black .'. But as you will see if you try 'flake8 .', a lot of python files (automatically generated by the database) contains lint errors, mainly from imports ('from package import function' instead of 'import function'), and lines too long.