### PR TITLE
🐞 fix(wordcloud): removed duplicate app.destroy()

### DIFF
--- a/src-front/src/components/WordCloud/WordCloud.tsx
+++ b/src-front/src/components/WordCloud/WordCloud.tsx
@@ -308,11 +308,6 @@ export default function WordCloud({
           //End of the game
           setIsGameEnded(true);
 
-          //deleting the PIXI App
-          if (refApp.current) {
-            refApp.current.destroy(true, { children: true, texture: true });
-            refApp.current = undefined;
-          }
           //deleting the canvas
           if (refCanvas.current) {
             while (refCanvas.current.firstChild) {


### PR DESCRIPTION
I mistakenly wrote a second call to PIXI.Application.destroy() yesterday. I just removed it.