### PR TITLE
🐞 fix(wordcloud): prevented the wordcloud init to be executed 2 times

### DIFF
--- a/src-front/src/components/WordCloud/WordCloud.tsx
+++ b/src-front/src/components/WordCloud/WordCloud.tsx
@@ -235,6 +235,7 @@ export default function WordCloud({
   //session initialization
   useEffect(() => {
     //setError("");
+    if (userId == null || userId.length == 0) return;
     console.log("Initializing session...");
     fightSession.current = new FightSession(userId, fightId, () => {
       console.log("WebSocket open. Getting state...");


### PR DESCRIPTION
The useEffect that initialises the Pixi App was executed 2 times because of recently added variables in its dependency array (line 287). More precisely; userId starts by being "", and somehow gets refreshed to contain the username. This refresh is what retriggered the useffect.